### PR TITLE
Veranstaltungsreihen

### DIFF
--- a/advanced-custom-fields/veranstaltungen.php
+++ b/advanced-custom-fields/veranstaltungen.php
@@ -107,7 +107,11 @@ if( function_exists('acf_add_local_field_group') ):
                 'key' => 'field_5fc8d0b28edb0',
                 'label' => __('Beschreibung','quartiersplattform'),
                 'name' => 'text',
-                'type' => 'textarea',
+                'type' => 'textarea', // 'wysiwyg'
+	//	'tabs' => 'visual',  // 'visual' || 'text' || 'all'
+	//	'toolbar' => 'basic',  // 'full' || 'basic'
+	//	'media_upload' => 1,
+	//	'delay' => 1,
                 'instructions' => __('Worum geht es bei deiner Veranstaltung?','quartiersplattform'),
                 'required' => 0,
                 'conditional_logic' => 0,
@@ -127,7 +131,7 @@ if( function_exists('acf_add_local_field_group') ):
                 'label' => __('Datum','quartiersplattform'),
                 'name' => 'event_date',
                 'type' => 'date_picker',
-                'instructions' => __('Wann wird deine Veranstaltung stattfinden?','quartiersplattform'),
+                'instructions' => __('Wann wird deine Veranstaltung stattfinden bzw. beginnen?','quartiersplattform'),
                 'required' => 1,
                 'conditional_logic' => 0,
                 'wrapper' => array(
@@ -135,7 +139,7 @@ if( function_exists('acf_add_local_field_group') ):
                     'class' => '',
                     'id' => '',
                 ),
-                'display_format' => 'F j, Y',
+                'display_format' => 'j. F Y',
                 'return_format' => 'Y-m-d',
                 'first_day' => 1,
             ),
@@ -171,6 +175,23 @@ if( function_exists('acf_add_local_field_group') ):
                 ),
                 'display_format' => 'H:i',
                 'return_format' => 'H:i:s',
+            ),
+            array(
+                'key' => 'field_5fc8d1ae96113',
+                'label' => __('Enddatum (bei mehrtägigen Veranstaltungen)','quartiersplattform'),
+                'name' => 'event_end_date',
+                'type' => 'date_picker',
+                'instructions' => __('Wann findet die mehrtägige Veranstaltung zuletzt statt?','quartiersplattform'),
+                'required' => 0,
+                'conditional_logic' => 0,
+                'wrapper' => array(
+                    'width' => '',
+                    'class' => '',
+                    'id' => '',
+                ),
+                'display_format' => 'j. F Y',
+                'return_format' => 'Y-m-d',
+                'first_day' => 1,
             ),
             array(
                 'key' => 'field_5fc8d1c4d15c8',
@@ -296,5 +317,5 @@ if( function_exists('acf_add_local_field_group') ):
         'active' => true,
         'description' => '',
     ));
-    
+
     endif;

--- a/components/calendar/calendar_download.php
+++ b/components/calendar/calendar_download.php
@@ -1,18 +1,25 @@
 <?php
 
-// needed variabels
-$date = get_field('event_date', $post);
-$time = get_field('event_time', $post);
-$time_end = get_field('event_end_time', $post);
+// needed variables
+$date_start = get_field('event_date', $post); // Start date
+$time_start = get_field('event_time', $post); // Start time
+$time_end = get_field('event_end_time', $post); // End time
+$date_end = get_field('event_end_date', $post); // End date
         
 $title = get_the_title();
-$start = date('Ymd', strtotime("$date $time")) . "T" . date('His', strtotime("$date $time"));
-$ende = date('Ymd', strtotime("$date $time")) . "T" . date('His', strtotime("$date $time_end"));
+$start = !empty($date_start) ? date('Ymd', strtotime("$date_start $time_start")) . "T" . date('His', strtotime("$date_start $time_start")) : '';
 
-if (empty($ende) || strtotime($start) > strtotime($ende) ) {
-    // one hour after start
-    $ende = date('Ymd', strtotime($start) + (60*60)) . "T" . date('His', strtotime($start) + (60*60));
+if (empty($date_end)) {
+    // Enddatum not given - single day event
+    $date_end = $date_start;
 }
+
+if (empty($time_end) || strtotime($start) > strtotime("$date_end $time_end")) {
+    // one hour after start
+    $time_end = date('H:i:s', strtotime("$time_start +1 hour"));
+}
+
+$ende = date('Ymd', strtotime("$date_end $time_end")) . "T" . date('His', strtotime("$date_end $time_end"));
 
 // directory
 $links = get_template_directory_uri();
@@ -28,18 +35,19 @@ else {
 }
 // acf fields - ticket
 if (get_field('ticket')) {
-    $website = get_field('ticket');'';
+    $website = get_field('ticket');
 }
 else {
     $website = '';
 }
 
-$description = get_field( "text" );
+$description = get_field("text");
 $file_name = $post->post_name;
 $dir = "/assets/generated/calendar-files/";
 
 $kb_start = $start;
 $kb_end = $ende;
+
 $kb_current_time = date("Ymd")."T".date("His");
 $kb_title = html_entity_decode($title, ENT_COMPAT, 'UTF-8');
 $kb_location = preg_replace('/([\,;])/','\\\$1',$location); 
@@ -71,7 +79,7 @@ $kb_ics_content =
     'DTEND:'.$kb_end.$eol.
     'LOCATION:'.$kb_location.$eol.
     'DTSTAMP:'.$kb_current_time.$eol.
-    // 'RRULE:FREQ='.$kb_freq.';UNTIL='.ende_der_widerholung.
+    //'RRULE:FREQ='.$kb_freq.';UNTIL='.$kb_until.$eol.
     'SUMMARY:'.$kb_title.$eol.
     'URL;VALUE=URI:'.$kb_url.$eol.
     'DESCRIPTION:'.$kb_description.$eol.

--- a/components/project/events.php
+++ b/components/project/events.php
@@ -11,57 +11,49 @@ $args_chronik = array(
             'terms'    => $post->post_name,
         ),
     ),
-    'meta_query'     => array(
-        'relation' => 'AND',
+    'meta_query' => array(
+        'relation' => 'OR',
         array(
-            'relation' => 'OR',
-            array(
+            'relation'    => 'AND',
+            'date_clause' => array(
                 'key'     => 'event_date',
                 'value'   => date('Y-m-d'),
                 'compare' => '>=',
                 'type'    => 'DATE'
             ),
-            array(
-                'relation' => 'AND',
-                array(
-                    'key'     => 'event_date',
-                    'value'   => date('Y-m-d'),
-                    'compare' => '<',
-                    'type'    => 'DATE'
-                ),
-                array(
-                    'relation' => 'OR',
-                    array(
-                        'key'     => 'event_end_date',
-                        'value'   => date('Y-m-d'),
-                        'compare' => '>=',
-                        'type'    => 'DATE'
-                    ),
-                    array(
-                        'key'     => 'event_end_date',
-                        'value'   => '',
-                        'compare' => '=',
-                    ),
-                ),
+            'time_clause' => array(
+                'key'     => 'event_time',
+                'compare' => '=',
             ),
         ),
         array(
-            'key'     => 'event_time',
-            'compare' => 'EXISTS',
-        ),        
+            'relation'    => 'AND',
+            'end_date_clause' => array(
+                'key' => 'event_end_date',
+                'value' => date('Y-m-d'),
+                'compare'   => '>=',
+                'type' => 'DATE'
+            ),
+            'end_time_clause' => array(
+                'key' => 'event_end_time',
+                'compare'   => '=',
+            ),
+            'date_clause' => array(
+                'key' => 'event_date',
+                'value' => date('Y-m-d'),
+                'compare'   => '<',
+                'type' => 'DATE'
+            ),
+        ),
     ),
     'orderby' => array(
-        'event_date'     => 'ASC',
-        'meta_value_num' => 'ASC',
-        'meta_key'       => 'event_end_date',
-        'event_time'     => 'ASC',
-        'ID'             => 'ASC'
+        'date_clause' => 'ASC',
+        'time_clause' => 'ASC',
     ),
 );
 
 if (count_query($args_chronik)) {
     echo "<h3 class='margin-bottom'>" . __('Aktuelle Veranstaltung', 'quartiersplattform') . "</h3>";
-
     card_list($args_chronik);
 }
 ?>

--- a/components/project/events.php
+++ b/components/project/events.php
@@ -1,38 +1,62 @@
 <?php
-// Aktuelle Veranstaltungen
+// Veranstaltungen
 $args_chronik = array(
-    'post_type' => 'veranstaltungen', 
-    'post_status' => 'publish', 
+    'post_type'      => 'veranstaltungen',
+    'post_status'    => 'publish',
     'posts_per_page' => 10,
-    'offset' => '0', 
-    'meta_query' => array(
-        'relation' => 'OR', // change relation to OR
-        'date_clause' => array(
-            'key' => 'event_date',
-            'value' => date("Y-m-d"),
-            'compare' => '>=',
-            'type' => 'DATE'
+    'tax_query'      => array(
+        array(
+            'taxonomy' => 'projekt',
+            'field'    => 'slug',
+            'terms'    => $post->post_name,
+        ),
+    ),
+    'meta_query'     => array(
+        'relation' => 'AND',
+        array(
+            'relation' => 'OR',
+            array(
+                'key'     => 'event_date',
+                'value'   => date('Y-m-d'),
+                'compare' => '>=',
+                'type'    => 'DATE'
+            ),
+            array(
+                'relation' => 'AND',
+                array(
+                    'key'     => 'event_date',
+                    'value'   => date('Y-m-d'),
+                    'compare' => '<',
+                    'type'    => 'DATE'
+                ),
+                array(
+                    'relation' => 'OR',
+                    array(
+                        'key'     => 'event_end_date',
+                        'value'   => date('Y-m-d'),
+                        'compare' => '>=',
+                        'type'    => 'DATE'
+                    ),
+                    array(
+                        'key'     => 'event_end_date',
+                        'value'   => '',
+                        'compare' => '=',
+                    ),
+                ),
+            ),
         ),
         array(
-            'key' => 'event_end_date',
-            'value' => date("Y-m-d"),
-            'compare' => '>=',
-            'type' => 'DATE'
-        ),
-        'time_clause' => array(
-            'key' => 'event_time',
-            'compare' => '=',
-        )
+            'key'     => 'event_time',
+            'compare' => 'EXISTS',
+        ),        
     ),
     'orderby' => array(
-        'date_clause' => 'ASC',
-        'time_clause' => 'ASC',
+        'event_date'     => 'ASC',
+        'meta_value_num' => 'ASC',
+        'meta_key'       => 'event_end_date',
+        'event_time'     => 'ASC',
+        'ID'             => 'ASC'
     ),
-    'tax_query' => array(
-        'taxonomy' => 'projekt',
-        'field' => 'slug',
-        'terms' => ".$post->post_name."
-    )
 );
 
 if (count_query($args_chronik)) {

--- a/components/project/events.php
+++ b/components/project/events.php
@@ -1,41 +1,43 @@
 <?php
 // Aktuelle Veranstaltungen
 $args_chronik = array(
-    'post_type'=>'veranstaltungen', 
-    'post_status'=>'publish', 
-    'posts_per_page'=> 10,
+    'post_type' => 'veranstaltungen', 
+    'post_status' => 'publish', 
+    'posts_per_page' => 10,
     'offset' => '0', 
     'meta_query' => array(
-        'relation' => 'AND',
+        'relation' => 'OR', // change relation to OR
         'date_clause' => array(
             'key' => 'event_date',
             'value' => date("Y-m-d"),
-            'compare'	=> '>=',
+            'compare' => '>=',
+            'type' => 'DATE'
+        ),
+        array(
+            'key' => 'event_end_date',
+            'value' => date("Y-m-d"),
+            'compare' => '>=',
             'type' => 'DATE'
         ),
         'time_clause' => array(
             'key' => 'event_time',
-            'compare'	=> '=',
-        ),
+            'compare' => '=',
+        )
     ),
     'orderby' => array(
         'date_clause' => 'ASC',
         'time_clause' => 'ASC',
     ),
     'tax_query' => array(
-        array(
-            'taxonomy' => 'projekt',
-            'field' => 'slug',
-            'terms' => ".$post->post_name."
-        )
+        'taxonomy' => 'projekt',
+        'field' => 'slug',
+        'terms' => ".$post->post_name."
     )
-
 );
 
 if (count_query($args_chronik)) {
-    echo "<h3 class='margin-bottom'>".__('Aktuelle Veranstaltung', 'quartiersplattform')."</h3>";
+    echo "<h3 class='margin-bottom'>" . __('Aktuelle Veranstaltung', 'quartiersplattform') . "</h3>";
 
     card_list($args_chronik);
 }
-
 ?>

--- a/components/views/veranstaltungen.php
+++ b/components/views/veranstaltungen.php
@@ -6,20 +6,30 @@ $veranstaltungen = array(
     'post_status'=>'publish', 
     'posts_per_page'=> -1,
     'offset' => '0', 
-    'meta_query' => array(
-        'relation' => 'AND',
-        'date_clause' => array(
-            'key' => 'event_date',
+    'meta_query' =>
+    array(
+        'relation' => 'OR',
+        'date_clause' =>
+        array(
+            'key' => 'event_end_date',
             'value' => date("Y-m-d"),
             'compare'	=> '>=',
             'type' => 'DATE'
         ),
-        'time_clause' => array(
-            'key' => 'event_time',
-            'compare'	=> '=',
+        array(
+            'key' => 'event_date',
+            'value' => date("Y-m-d"),
+            'compare'   => '>=',
+            'type' => 'DATE'
         ),
     ),
-    'orderby' => array(
+    'time_clause' =>
+    array(
+        'key' => 'event_time',
+        'compare'	=> '=',
+    ),
+    'orderby' =>
+    array(
         'date_clause' => 'ASC',
         'time_clause' => 'ASC',
     ),

--- a/components/views/veranstaltungen.php
+++ b/components/views/veranstaltungen.php
@@ -6,51 +6,44 @@ $veranstaltungen = array(
     'post_status'    => 'publish',
     'posts_per_page' => -1,
     'offset'         => '0',
-    'meta_query'     => array(
-        'relation' => 'AND',
+    'meta_query' => array(
+        'relation' => 'OR',
         array(
-            'relation' => 'OR',
-            array(
+            'relation'    => 'AND',
+            'date_clause' => array(
                 'key'     => 'event_date',
                 'value'   => date('Y-m-d'),
                 'compare' => '>=',
                 'type'    => 'DATE'
             ),
-            array(
-                'relation' => 'AND',
-                array(
-                    'key'     => 'event_date',
-                    'value'   => date('Y-m-d'),
-                    'compare' => '<',
-                    'type'    => 'DATE'
-                ),
-                array(
-                    'relation' => 'OR',
-                    array(
-                        'key'     => 'event_end_date',
-                        'value'   => date('Y-m-d'),
-                        'compare' => '>=',
-                        'type'    => 'DATE'
-                    ),
-                    array(
-                        'key'     => 'event_end_date',
-                        'value'   => '',
-                        'compare' => '=',
-                    ),
-                ),
+            'time_clause' => array(
+                'key'     => 'event_time',
+                'compare' => '=',
             ),
         ),
         array(
-            'key'     => 'event_time',
-            'compare' => 'EXISTS',
-        ),        
+            'relation'    => 'AND',
+            'end_date_clause' => array(
+                'key' => 'event_end_date',
+                'value' => date('Y-m-d'),
+                'compare'   => '>=',
+                'type' => 'DATE'
+            ),
+            'end_time_clause' => array(
+                'key' => 'event_end_time',
+                'compare'   => '=',
+            ),
+            'date_clause' => array(
+                'key' => 'event_date',
+                'value' => date('Y-m-d'),
+                'compare'   => '<',
+                'type' => 'DATE'
+            ),
+        ),
     ),
     'orderby' => array(
-        'event_date'     => 'ASC',
-        'meta_value_num' => 'ASC',
-        'meta_key'       => 'event_end_date',
-        'event_time'     => 'ASC',
-        'ID'             => 'ASC'
+        'date_clause' => 'ASC',
+        'time_clause' => 'ASC',
     ),
 );
 

--- a/components/views/veranstaltungen.php
+++ b/components/views/veranstaltungen.php
@@ -2,36 +2,55 @@
 
 // Aktuelle veranstaltungen
 $veranstaltungen = array(
-    'post_type'=>'veranstaltungen', 
-    'post_status'=>'publish', 
-    'posts_per_page'=> -1,
-    'offset' => '0', 
-    'meta_query' =>
-    array(
-        'relation' => 'OR',
-        'date_clause' =>
+    'post_type'      => 'veranstaltungen',
+    'post_status'    => 'publish',
+    'posts_per_page' => -1,
+    'offset'         => '0',
+    'meta_query'     => array(
+        'relation' => 'AND',
         array(
-            'key' => 'event_end_date',
-            'value' => date("Y-m-d"),
-            'compare'	=> '>=',
-            'type' => 'DATE'
+            'relation' => 'OR',
+            array(
+                'key'     => 'event_date',
+                'value'   => date('Y-m-d'),
+                'compare' => '>=',
+                'type'    => 'DATE'
+            ),
+            array(
+                'relation' => 'AND',
+                array(
+                    'key'     => 'event_date',
+                    'value'   => date('Y-m-d'),
+                    'compare' => '<',
+                    'type'    => 'DATE'
+                ),
+                array(
+                    'relation' => 'OR',
+                    array(
+                        'key'     => 'event_end_date',
+                        'value'   => date('Y-m-d'),
+                        'compare' => '>=',
+                        'type'    => 'DATE'
+                    ),
+                    array(
+                        'key'     => 'event_end_date',
+                        'value'   => '',
+                        'compare' => '=',
+                    ),
+                ),
+            ),
         ),
         array(
-            'key' => 'event_date',
-            'value' => date("Y-m-d"),
-            'compare'   => '>=',
-            'type' => 'DATE'
-        ),
+            'key'     => 'event_time',
+            'compare' => 'EXISTS',
+        ),        
     ),
-    'time_clause' =>
-    array(
-        'key' => 'event_time',
-        'compare'	=> '=',
-    ),
-    'orderby' =>
-    array(
-        'date_clause' => 'ASC',
-        'time_clause' => 'ASC',
+    'orderby' => array(
+        'event_date'     => 'ASC',
+        'meta_value_num' => 'ASC',
+        'meta_key'       => 'event_end_date',
+        'event_time'     => 'ASC',
+        'ID'             => 'ASC'
     ),
 );
 

--- a/elements/card-veranstaltungen.php
+++ b/elements/card-veranstaltungen.php
@@ -41,7 +41,15 @@ else {
 
         <div class="veranstaltung card landscape background-image  shadow gardient"  style="background-image: url('<?php the_post_thumbnail_url('landscape_m') ?>')"> 
             <a class="card-link" href="<?php echo esc_url( get_permalink() ); ?>">
-                <span class="date"><?php _e('Veranstaltung', 'quartiersplattform'); ?> - <?php echo qp_date(get_field('event_date')); ?></span>
+                <span class="date">
+                <?php
+                if (get_field('event_end_date')) {
+                    echo _e('Veranstaltungsreihe', 'quartiersplattform')." - ".__('bis','quartiersplattform')." ".qp_date(get_field('event_end_date'), false, get_field('event_end_time'));
+                    } else {
+                    echo _e('Veranstaltung', 'quartiersplattform')." - ".qp_date(get_field('event_date'));
+                    }
+                ?>
+                </span>
                 <div class="content">
                     <h3 class="heading-size-3 "><?php shorten(get_the_title(), '30'); ?></h3>
                     <?php if (get_post_status() == 'draft' && qp_project_owner()) { ?>
@@ -69,7 +77,15 @@ else {
 
     <div class="card shadow veranstaltung-ohne-bild">
         <a class="card-link" href="<?php echo esc_url( get_permalink() ); ?>">
-        <span class="date"><?php _e('Veranstaltung', 'quartiersplattform'); ?> - <?php echo qp_date(get_field('event_date')); ?></span>
+        <span class="date">
+        <?php
+            if (get_field('event_end_date')) {
+                echo _e('Veranstaltungsreihe', 'quartiersplattform')." - ".__('bis','quartiersplattform')." ".qp_date(get_field('event_end_date'), false, get_field('event_end_time'));
+            } else {
+                echo _e('Veranstaltung', 'quartiersplattform')." - ".qp_date(get_field('event_date'));
+            }
+            ?>
+            </span>
 
             <div class="content">
                 <h3 class="heading-size-3 small-margin-bottom">

--- a/elements/card-veranstaltungen.php
+++ b/elements/card-veranstaltungen.php
@@ -44,7 +44,7 @@ else {
                 <span class="date">
                 <?php
                 if (get_field('event_end_date')) {
-                    echo _e('Veranstaltungsreihe', 'quartiersplattform')." - ".__('bis','quartiersplattform')." ".qp_date(get_field('event_end_date'), false, get_field('event_end_time'));
+                    echo _e('Aktion', 'quartiersplattform')." - ".qp_date(get_field('event_date'))." - ".qp_date(get_field('event_end_date'));
                     } else {
                     echo _e('Veranstaltung', 'quartiersplattform')." - ".qp_date(get_field('event_date'));
                     }
@@ -80,7 +80,7 @@ else {
         <span class="date">
         <?php
             if (get_field('event_end_date')) {
-                echo _e('Veranstaltungsreihe', 'quartiersplattform')." - ".__('bis','quartiersplattform')." ".qp_date(get_field('event_end_date'), false, get_field('event_end_time'));
+                echo _e('Aktion', 'quartiersplattform')." - ".qp_date(get_field('event_date'))." - ".qp_date(get_field('event_end_date'));
             } else {
                 echo _e('Veranstaltung', 'quartiersplattform')." - ".qp_date(get_field('event_date'));
             }

--- a/pages/form-veranstaltungen.php
+++ b/pages/form-veranstaltungen.php
@@ -63,10 +63,11 @@ if ( qp_project_owner($_GET['project']) == false ) {
                             'post_title' => true,
                             'uploader' => qp_form_uploader(),
                             'fields' => array(
-                                'field_5fc8d0b28edb0', //Text
+                                'field_5fc8d0b28edb0', //Beschreibung
                                 'field_5fc8d15b8765b', //Date
                                 'field_5fc8d16e8765c', //Start AP1
-                                'field_5fc8d18b8765d', //End AP1 
+                                'field_5fc8d18b8765d', //End AP1
+                                'field_5fc8d1ae96113', //EndDate
                                 'field_5fc8d1e0d15c9', //Livestream
                                 'field_5fc8d1f4d15ca', //Ticket
                                 'field_5fc8d1c4d15c8', //Website

--- a/pages/page-quartier.php
+++ b/pages/page-quartier.php
@@ -105,24 +105,36 @@ get_header();
             <p><?php _e("Verpasse keine Veranstaltung mehr in deinem Quartier. Egal ob das nächste Konzert oder die nächste Party in deiner Nachbarschaft - mit der Quartiersplattform bist du immer auf dem Laufenden!", "quartiersplattform"); ?></p>
             <div class="link-card-container force-landscape">
                 <?php 
-                        $args4 = array(
+                        $args4 =
+                        array(
                             'post_type'=>'veranstaltungen', 
                             'post_status'=>'publish', 
                             'posts_per_page'=> 20,
-                            'meta_query' => array(
-                                'relation' => 'AND',
-                                'date_clause' => array(
+                            'meta_query' =>
+                            array(
+                                'relation' => 'OR',
+                                'date_clause' =>
+                                array(
+                                    'key' => 'event_end_date',
+                                    'value' => date('Y-m-d'),
+                                    'compare' => '>=',
+                                    'type' => 'DATE',
+                                ),
+                                array(
                                     'key' => 'event_date',
                                     'value' => date("Y-m-d"),
-                                    'compare'	=> '>=',
+                                    'compare' => '>=',
                                     'type' => 'DATE'
                                 ),
-                                'time_clause' => array(
-                                    'key' => 'event_time',
-                                    'compare'	=> '=',
-                                ),
                             ),
-                            'orderby' => array(
+                            'time_clause' =>
+                            array(
+                                'relation' => 'AND',
+                                'key' => 'event_time',
+                                'compare' => '=',
+                            ),
+                            'orderby' =>
+                            array(
                                 'date_clause' => 'ASC',
                                 'time_clause' => 'ASC',
                             ),

--- a/pages/page-quartier.php
+++ b/pages/page-quartier.php
@@ -111,51 +111,44 @@ get_header();
                         'post_status'    => 'publish',
                         'posts_per_page' => 20,
                         'offset'         => '0',
-                        'meta_query'     => array(
-                            'relation' => 'AND',
+                        'meta_query' => array(
+                            'relation' => 'OR',
                             array(
-                                'relation' => 'OR',
-                                array(
+                                'relation'    => 'AND',
+                                'date_clause' => array(
                                     'key'     => 'event_date',
                                     'value'   => date('Y-m-d'),
                                     'compare' => '>=',
                                     'type'    => 'DATE'
                                 ),
-                                array(
-                                    'relation' => 'AND',
-                                    array(
-                                        'key'     => 'event_date',
-                                        'value'   => date('Y-m-d'),
-                                        'compare' => '<',
-                                        'type'    => 'DATE'
-                                    ),
-                                    array(
-                                        'relation' => 'OR',
-                                        array(
-                                            'key'     => 'event_end_date',
-                                            'value'   => date('Y-m-d'),
-                                            'compare' => '>=',
-                                            'type'    => 'DATE'
-                                        ),
-                                        array(
-                                            'key'     => 'event_end_date',
-                                            'value'   => '',
-                                            'compare' => '=',
-                                        ),
-                                    ),
+                                'time_clause' => array(
+                                    'key'     => 'event_time',
+                                    'compare' => '=',
                                 ),
                             ),
                             array(
-                                'key'     => 'event_time',
-                                'compare'   => 'EXISTS',
-                            ),        
+                                'relation'    => 'AND',
+                                'end_date_clause' => array(
+                                    'key' => 'event_end_date',
+                                    'value' => date('Y-m-d'),
+                                    'compare'   => '>=',
+                                    'type' => 'DATE'
+                                ),
+                                'end_time_clause' => array(
+                                    'key' => 'event_end_time',
+                                    'compare'   => '=',
+                                ),
+                                'date_clause' => array(
+                                    'key' => 'event_date',
+                                    'value' => date('Y-m-d'),
+                                    'compare'   => '<',
+                                    'type' => 'DATE'
+                                ),
+                            ),
                         ),
                         'orderby' => array(
-                            'event_date'     => 'ASC',
-                            'meta_value_num' => 'ASC',
-                            'meta_key'       => 'event_end_date',
-                            'event_time'     => 'ASC',
-                            'ID'             => 'ASC'
+                            'date_clause' => 'ASC',
+                            'time_clause' => 'ASC',
                         ),
                     );
                 ?>

--- a/pages/page-quartier.php
+++ b/pages/page-quartier.php
@@ -104,42 +104,61 @@ get_header();
             <h2 class="heading-size-1 stage-title"><?php _e("Veranstaltungen in deinem Quartier", "quartiersplattform"); ?></h2>
             <p><?php _e("Verpasse keine Veranstaltung mehr in deinem Quartier. Egal ob das nächste Konzert oder die nächste Party in deiner Nachbarschaft - mit der Quartiersplattform bist du immer auf dem Laufenden!", "quartiersplattform"); ?></p>
             <div class="link-card-container force-landscape">
-                <?php 
-                        $args4 =
-                        array(
-                            'post_type'=>'veranstaltungen', 
-                            'post_status'=>'publish', 
-                            'posts_per_page'=> 20,
-                            'meta_query' =>
+                <?php
+                    $args4 =
+                    array(
+                        'post_type'      => 'veranstaltungen',
+                        'post_status'    => 'publish',
+                        'posts_per_page' => 20,
+                        'offset'         => '0',
+                        'meta_query'     => array(
+                            'relation' => 'AND',
                             array(
                                 'relation' => 'OR',
-                                'date_clause' =>
                                 array(
-                                    'key' => 'event_end_date',
-                                    'value' => date('Y-m-d'),
+                                    'key'     => 'event_date',
+                                    'value'   => date('Y-m-d'),
                                     'compare' => '>=',
-                                    'type' => 'DATE',
+                                    'type'    => 'DATE'
                                 ),
                                 array(
-                                    'key' => 'event_date',
-                                    'value' => date("Y-m-d"),
-                                    'compare' => '>=',
-                                    'type' => 'DATE'
+                                    'relation' => 'AND',
+                                    array(
+                                        'key'     => 'event_date',
+                                        'value'   => date('Y-m-d'),
+                                        'compare' => '<',
+                                        'type'    => 'DATE'
+                                    ),
+                                    array(
+                                        'relation' => 'OR',
+                                        array(
+                                            'key'     => 'event_end_date',
+                                            'value'   => date('Y-m-d'),
+                                            'compare' => '>=',
+                                            'type'    => 'DATE'
+                                        ),
+                                        array(
+                                            'key'     => 'event_end_date',
+                                            'value'   => '',
+                                            'compare' => '=',
+                                        ),
+                                    ),
                                 ),
                             ),
-                            'time_clause' =>
                             array(
-                                'relation' => 'AND',
-                                'key' => 'event_time',
-                                'compare' => '=',
-                            ),
-                            'orderby' =>
-                            array(
-                                'date_clause' => 'ASC',
-                                'time_clause' => 'ASC',
-                            ),
-                        );
-                    ?>  
+                                'key'     => 'event_time',
+                                'compare'   => 'EXISTS',
+                            ),        
+                        ),
+                        'orderby' => array(
+                            'event_date'     => 'ASC',
+                            'meta_value_num' => 'ASC',
+                            'meta_key'       => 'event_end_date',
+                            'event_time'     => 'ASC',
+                            'ID'             => 'ASC'
+                        ),
+                    );
+                ?>
                     <?php card_list($args4);?>
                 </div>
                 <a class="button is-primary" href="<?php echo get_site_url()."/veranstaltungen"; ?>"><?php _e("Zu den Veranstaltungen", "quartiersplattform"); ?></a>

--- a/pages/single-veranstaltungen.php
+++ b/pages/single-veranstaltungen.php
@@ -56,7 +56,24 @@ get_header();
                 // get project by Term
                 ?>
                 <h2 class="heading-size-3 highlight">
-                    <span class="date"><?php _e('Veranstaltung', 'quartiersplattform'); ?> <br> <?php echo qp_date(get_field('event_date'), true, get_field('event_time')); if (get_field('event_end_time')) echo " ".__('bis','quartiersplattform')." ".qp_date(get_field('event_date'), true, get_field('event_end_time'), true); ?></span>
+                    <span class="date">
+
+                    <?php
+                        if (get_field('event_end_date')) {
+		            echo _e('Veranstaltungsreihe', 'quartiersplattform'). "<br>";
+                            echo qp_date(get_field('event_date'), false, get_field('event_time'));
+                            echo " ".__('bis','quartiersplattform')." ".qp_date(get_field('event_end_date'), false, get_field('event_end_time'));
+                        } else {
+                            echo _e('Veranstaltung', 'quartiersplattform'). "<br>";
+                            echo qp_date(get_field('event_date'), true, get_field('event_time'));
+                            if (get_field('event_end_time')) {
+                            	echo " ".__('bis','quartiersplattform')." ".qp_date(get_field('event_date'), true, get_field('event_end_time'), true) . " Uhr <br>";
+                            } else {
+                            echo " Uhr";
+                            }
+                        }
+                    ?>
+                    </span>
                 </h2>
                 <h1 class="heading-size-1 large-margin-bottom"><?php the_title(); ?></h1>
                 
@@ -197,7 +214,8 @@ get_header();
                             'field_5fc8d0b28edb0', //Text
                             'field_5fc8d15b8765b', //Date
                             'field_5fc8d16e8765c', //Start 
-                            'field_5fc8d18b8765d', //End  
+                            'field_5fc8d18b8765d', //End
+                            'field_5fc8d1ae96113', //EndDate
                             'field_5fc8d1e0d15c9', //Livestream
                             'field_5fc8d1f4d15ca', //Ticket
                             'field_5fc8d1c4d15c8', //Website

--- a/pages/single-veranstaltungen.php
+++ b/pages/single-veranstaltungen.php
@@ -60,16 +60,20 @@ get_header();
 
                     <?php
                         if (get_field('event_end_date')) {
-		            echo _e('Veranstaltungsreihe', 'quartiersplattform'). "<br>";
-                            echo qp_date(get_field('event_date'), false, get_field('event_time'));
-                            echo " ".__('bis','quartiersplattform')." ".qp_date(get_field('event_end_date'), false, get_field('event_end_time'));
+		            echo _e('Aktion', 'quartiersplattform'). "<br>";
+                            echo qp_date(get_field('event_date'));
+                            if (get_field('event_end_time')) {
+                                echo " ".__('bis','quartiersplattform')." ".qp_date(get_field('event_end_date'), true, get_field('event_end_time'))." ".__('Uhr','quartiersplattform');
+                            } else {
+                                echo " ".__('bis','quartiersplattform')." ".qp_date(get_field('event_end_date'));
+                            }
                         } else {
                             echo _e('Veranstaltung', 'quartiersplattform'). "<br>";
                             echo qp_date(get_field('event_date'), true, get_field('event_time'));
                             if (get_field('event_end_time')) {
-                            	echo " ".__('bis','quartiersplattform')." ".qp_date(get_field('event_date'), true, get_field('event_end_time'), true) . " Uhr <br>";
+                            	echo " ".__('bis','quartiersplattform')." ".qp_date(get_field('event_date'), true, get_field('event_end_time'), true)." ".__('Uhr','quartiersplattform')."<br>";
                             } else {
-                            echo " Uhr";
+                            echo " ".__('Uhr','quartiersplattform');
                             }
                         }
                     ?>

--- a/pages/single-veranstaltungen.php
+++ b/pages/single-veranstaltungen.php
@@ -211,7 +211,7 @@ get_header();
                         'return' => get_site_url().'/projekte'.'/', 
                         'uploader' => qp_form_uploader(),
                         'fields' => array(
-                            'field_5fc8d0b28edb0', //Text
+                            'field_5fc8d0b28edb0', //Beschreibung
                             'field_5fc8d15b8765b', //Date
                             'field_5fc8d16e8765c', //Start 
                             'field_5fc8d18b8765d', //End
@@ -239,10 +239,10 @@ get_header();
 <div class="right-sidebar">
         <?php
         // weitere Nachrichten
-		$args2 = array(
-			'post_type'=> array('veranstaltungen'), 
-			'post_status'=>'publish', 
-			'posts_per_page'=> 6,
+        $args2 = array(
+            'post_type'=> array('veranstaltungen'), 
+            'post_status'=>'publish', 
+            'posts_per_page'=> 6,
             // 'order' => 'DESC',
             'post__not_in' => array(get_the_ID()),
             'offset' => '0', 


### PR DESCRIPTION
Adds option to add events lasting multiple days with adding an 'event_end_date' field

TODO:
* Translations

This allows adding multiday events (_Mehrtagesveranstaltungen_ - called them **Veranstaltungsreihe**) by adding an end date to an event. This is useful for things like "call to actions" or "Beteiligungsverfahren".

This should (partly) fix https://github.com/studio-arrenberg/quartiersplattform/issues/135

Recurring events, like daily, weekly, monthly events (_Stammtische_, etc. ) are more complex to add, as it needs loops to create multiple single events and it needs loops to edit, delete, etc. those events. It even would be possible to have those events recurring x-times or until some date, etc. Some events, like '_Quartierstreffen_' or others take place on every last friday in a month, every third monday, etc. ... would be a nice to have, but it's still a _Quartiersplattform_, not a calendar ;)

Open for comments and testing ;)